### PR TITLE
Fix command shortcut ctrl-or-cmd behavior

### DIFF
--- a/src/super-action/command/ActionCommandKeyboardShortcut.tsx
+++ b/src/super-action/command/ActionCommandKeyboardShortcut.tsx
@@ -18,7 +18,7 @@ export const ActionCommandKeyboardShortcut = ({
     const down = async (e: KeyboardEvent) => {
       if (e.target !== document.body) return
       if (e.key.toLowerCase() !== shortcut.key.toLowerCase()) return
-      if (shortcut.cmdCtrl && (!e.metaKey || !e.ctrlKey)) return
+      if (shortcut.cmdCtrl && !e.metaKey && !e.ctrlKey) return
       if (shortcut.shift && !e.shiftKey) return
       // if (shortcut.alt && !e.altKey) return
 


### PR DESCRIPTION
## Summary
- correct logic for keyboard shortcuts so Cmd or Ctrl trigger

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm ts:check` *(fails: dependencies missing)*