### PR TITLE
Force active org context for logged-in users

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ This template has a dual-mode Playwright setup:
 - `pnpm e2e:dev` is intended for humans doing interactive local debugging.
 - `pnpm neon:dev:*` commands are human workflows and should not be required for agent E2E verification.
 
+### Starter config and E2E assumptions
+
+- The shipped E2E suite covers the default starter mode from [`src/lib/starter.config.tsx`](src/lib/starter.config.tsx):
+- `ORGS.isActive = true`
+- `LOCALIZATION.isActive = true`
+- `SIDEBAR.activeInMain = 'loggedIn'`
+- `ORGS.forceOrg = true`
+- If you change one of these behavior flags, update the affected routing/sidebar tests alongside the config change.
+
 ### Setup
 
 - Install Playwright browser once:

--- a/e2e/specs/admin-impersonation.spec.ts
+++ b/e2e/specs/admin-impersonation.spec.ts
@@ -22,10 +22,10 @@ test('admin can impersonate another admin and switch back', async ({
   await page.getByTestId('users-search-submit').click()
   await expect(main.getByTestId(`user-row-${adminAlt.id}`)).toBeVisible()
 
-  await page.getByTestId(`impersonate-button-${adminAlt.id}`).click()
-  const adminAltImpersonateButton = page.getByTestId(
-    `impersonate-button-${adminAlt.id}`,
-  )
+  await page.getByTestId(`impersonate-button-${adminAlt.id}`).first().click()
+  const adminAltImpersonateButton = page
+    .getByTestId(`impersonate-button-${adminAlt.id}`)
+    .first()
   await expect(adminAltImpersonateButton).toBeDisabled()
   await expect(adminAltImpersonateButton).toHaveAttribute(
     'title',
@@ -36,10 +36,10 @@ test('admin can impersonate another admin and switch back', async ({
   await page.getByTestId('users-search-submit').click()
   await expect(main.getByTestId(`user-row-${owner.id}`)).toBeVisible()
 
-  await page.getByTestId(`impersonate-button-${owner.id}`).click()
-  const ownerImpersonateButton = page.getByTestId(
-    `impersonate-button-${owner.id}`,
-  )
+  await page.getByTestId(`impersonate-button-${owner.id}`).first().click()
+  const ownerImpersonateButton = page
+    .getByTestId(`impersonate-button-${owner.id}`)
+    .first()
   await expect(ownerImpersonateButton).toBeDisabled()
   await expect(ownerImpersonateButton).toHaveAttribute('title', /current user/i)
 })

--- a/e2e/specs/force-org.spec.ts
+++ b/e2e/specs/force-org.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test, type Page } from '@playwright/test'
+import { baseURL, loginWithCredentials } from '../support/auth'
+import { getPartitionForWorker } from '../support/seed-manifest'
+
+const setLastUsedOrgCookie = async ({
+  page,
+  orgSlug,
+}: {
+  page: Page
+  orgSlug: string
+}) => {
+  await page.context().addCookies([
+    {
+      name: 'LastusedOrg',
+      value: orgSlug,
+      url: baseURL,
+    },
+  ])
+}
+
+test('zero-org users get an org auto-created and see it in the switcher', async ({
+  page,
+}, testInfo) => {
+  const partition = getPartitionForWorker(testInfo)
+  const candidate = partition.users.candidate
+
+  await loginWithCredentials({
+    page,
+    email: candidate.email,
+    password: candidate.password,
+  })
+
+  await page.goto('/app')
+  await expect(page).toHaveURL(new RegExp(`/org/${candidate.id}$`))
+  await expect(page.getByTestId('sidebar-org-switcher-trigger')).toContainText(
+    `E2E Candidate ${partition.index}`,
+  )
+})
+
+test('global main routes keep their URL and use the cookie-selected org context', async ({
+  page,
+}, testInfo) => {
+  const partition = getPartitionForWorker(testInfo)
+  const owner = partition.users.owner
+
+  await loginWithCredentials({
+    page,
+    email: owner.email,
+    password: owner.password,
+  })
+
+  await setLastUsedOrgCookie({
+    page,
+    orgSlug: partition.orgs.invites,
+  })
+
+  await page.goto('/users')
+  await expect(page).toHaveURL(/\/users$/)
+  await expect(page.getByTestId('sidebar-org-switcher-trigger')).toContainText(
+    `E2E Invites Org ${partition.index}`,
+  )
+  await expect(page.getByRole('link', { name: 'Say Hello' })).toHaveAttribute(
+    'href',
+    `/org/${partition.orgs.invites}?say=hello`,
+  )
+})
+
+test('invalid LastusedOrg values fall back to the latest membership deterministically', async ({
+  page,
+}, testInfo) => {
+  const partition = getPartitionForWorker(testInfo)
+  const owner = partition.users.owner
+
+  await loginWithCredentials({
+    page,
+    email: owner.email,
+    password: owner.password,
+  })
+
+  await setLastUsedOrgCookie({
+    page,
+    orgSlug: 'missing-org',
+  })
+
+  await page.goto('/users')
+  await expect(page).toHaveURL(/\/users$/)
+  await expect(page.getByTestId('sidebar-org-switcher-trigger')).toContainText(
+    `E2E Join Edge Org ${partition.index}`,
+  )
+  expect(
+    await page.evaluate(
+      ([name, value]) => document.cookie.includes(`${name}=${value}`),
+      ['LastusedOrg', partition.orgs.joinEdge] as const,
+    ),
+  ).toBe(true)
+})

--- a/e2e/specs/invite-and-mail.spec.ts
+++ b/e2e/specs/invite-and-mail.spec.ts
@@ -115,7 +115,7 @@ test('normal invites and mail invites can be created and consumed', async ({
 
   await page.goto(`/org/${invitesOrgSlug}/settings/members`)
 
-  await page.getByTestId('invite-normal-create-button').click()
+  await page.getByTestId('invite-normal-create-button').first().click()
   await page.getByTestId('invite-create-submit').click()
 
   const normalInviteRow = page
@@ -141,7 +141,7 @@ test('normal invites and mail invites can be created and consumed', async ({
   })
   await candidateContext.close()
 
-  await page.getByTestId('invite-mail-create-button').click()
+  await page.getByTestId('invite-mail-create-button').first().click()
   await page.getByTestId('invite-email-receiver-input').fill(mailUser.email)
   await page.getByTestId('invite-email-receiver-input').press('Enter')
   await page.getByTestId('invite-email-submit').click()

--- a/e2e/specs/invite-management.spec.ts
+++ b/e2e/specs/invite-management.spec.ts
@@ -27,7 +27,7 @@ test('normal invite codes can be deleted and mail invites can be resent and dele
       .filter((id): id is string => !!id)
   })
 
-  await page.getByTestId('invite-normal-create-button').click()
+  await page.getByTestId('invite-normal-create-button').first().click()
   await page.getByTestId('invite-create-submit').click()
 
   let createdCodeId: string | null = null
@@ -60,7 +60,7 @@ test('normal invite codes can be deleted and mail invites can be resent and dele
   await expect(createdCodeRow).toHaveCount(0)
 
   const receiverEmail = `e2e-resend-${partition.index}-${Date.now()}@example.com`
-  await page.getByTestId('invite-mail-create-button').click()
+  await page.getByTestId('invite-mail-create-button').first().click()
   await page.getByTestId('invite-email-receiver-input').fill(receiverEmail)
   await page.getByTestId('invite-email-receiver-input').press('Enter')
 

--- a/e2e/specs/landing-and-routing.spec.ts
+++ b/e2e/specs/landing-and-routing.spec.ts
@@ -47,6 +47,7 @@ test('logged-in root and login page redirects behave as expected', async ({
 }, testInfo) => {
   const partition = getPartitionForWorker(testInfo)
   const owner = partition.users.owner
+  const activeOrgSlug = partition.orgs.joinEdge
 
   await loginWithCredentials({
     page,
@@ -55,7 +56,10 @@ test('logged-in root and login page redirects behave as expected', async ({
   })
 
   await page.goto('/')
-  await expect(page).toHaveURL(/\/app/)
+  await expect(page).toHaveURL(new RegExp(`/org/${activeOrgSlug}$`))
+
+  await page.goto('/app')
+  await expect(page).toHaveURL(new RegExp(`/org/${activeOrgSlug}$`))
 
   await page.goto('/auth/login?redirect=%2Fusers')
   await expect(page).toHaveURL(/\/users/)

--- a/src/app/(main)/app/page.tsx
+++ b/src/app/(main)/app/page.tsx
@@ -1,11 +1,23 @@
 import { getMyUserOrLogin } from '@/auth/getMyUser'
 import { TopHeader } from '@/components/TopHeader'
 import { getTranslations } from '@/i18n/getTranslations'
+import { ORGS } from '@/lib/starter.config'
+import { resolveCurrentOrgContext } from '@/organization/resolveCurrentOrgContext'
+import { redirect } from 'next/navigation'
 
 export default async function Page() {
   await getMyUserOrLogin({
     forceRedirectUrl: '/app',
   })
+
+  if (ORGS.forceOrg) {
+    const orgContext = await resolveCurrentOrgContext()
+    if (!orgContext) {
+      throw new Error('Active organization context is required for /app.')
+    }
+    redirect(`/org/${orgContext.org.slug}`)
+  }
+
   const t = await getTranslations()
   return (
     <>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,7 +1,9 @@
+import { getIsLoggedIn } from '@/auth/getMyUser'
 import { MainTopLayout } from '@/components/layout/MainTopLayout'
 import { RootLayout } from '@/components/layout/RootLayout'
 import { getIsSidebarActive } from '@/components/sidebar/getIsSidebarActive'
 import { SidebarLayout } from '@/components/sidebar/SidebarLayout'
+import { ORGS } from '@/lib/starter.config'
 
 export { metadata } from '@/components/layout/RootLayout'
 
@@ -10,7 +12,10 @@ export default async function Layout({
 }: {
   children: React.ReactNode
 }) {
-  const activeInMain = await getIsSidebarActive()
+  const isLoggedIn = await getIsLoggedIn()
+  const activeInMain =
+    isLoggedIn && ORGS.forceOrg ? true : await getIsSidebarActive()
+
   const content = activeInMain ? (
     <SidebarLayout>{children}</SidebarLayout>
   ) : (

--- a/src/app/(main)/users/ImpersonateButton.tsx
+++ b/src/app/(main)/users/ImpersonateButton.tsx
@@ -7,11 +7,9 @@ import { useSuperAction } from '@/super-action/action/useSuperAction'
 import { SuperLoadingIcon } from '@/super-action/button/SuperLoadingIcon'
 import { Check, VenetianMask } from 'lucide-react'
 import { useSession } from 'next-auth/react'
-import { useRouter } from 'next/navigation'
 
 export const ImpersonateButton = ({ userId }: { userId: string }) => {
-  const { data: session, update } = useSession()
-  const router = useRouter()
+  const { data: session } = useSession()
   const isCurrentUser = session?.user?.id === userId
   const t = useTranslations()
   const buttonLabel = isCurrentUser
@@ -34,8 +32,7 @@ export const ImpersonateButton = ({ userId }: { userId: string }) => {
           if (isCurrentUser) return
 
           await trigger({ userId })
-          update() // Force update session
-          router.refresh() // Force Reload page and layout
+          window.location.reload()
         }}
       >
         <span className="sr-only">{buttonLabel}</span>

--- a/src/app/org/[orgSlug]/layout.tsx
+++ b/src/app/org/[orgSlug]/layout.tsx
@@ -15,9 +15,12 @@ export default async function Layout({
   if (!ORGS.isActive) {
     redirect('/')
   }
+
+  const { orgSlug } = await params
+
   return (
     <RootLayout>
-      <SidebarLayout params={params}>{children}</SidebarLayout>
+      <SidebarLayout routeOrgSlug={orgSlug}>{children}</SidebarLayout>
     </RootLayout>
   )
 }

--- a/src/app/route.ts
+++ b/src/app/route.ts
@@ -1,18 +1,24 @@
-import { getIsLoggedIn } from '@/auth/getMyUser'
+import { getMyUser } from '@/auth/getMyUser'
 import { getMyLocale } from '@/i18n/getMyLocale'
+import { ORGS } from '@/lib/starter.config'
+import { resolveCurrentOrgContext } from '@/organization/resolveCurrentOrgContext'
 import { redirect } from 'next/navigation'
 
 export const GET = async () => {
-  const isLoggedIn = await getIsLoggedIn()
+  const user = await getMyUser()
 
-  // TODO: redirect to latest org?
+  if (user && ORGS.forceOrg) {
+    const orgContext = await resolveCurrentOrgContext()
+    if (!orgContext) {
+      throw new Error('Active organization context is required for /.')
+    }
+    redirect(`/org/${orgContext.org.slug}`)
+  }
 
-  // Redirect to dashboard
-  if (isLoggedIn) {
+  if (user) {
     redirect('/app')
   }
 
-  // Redirect to landing page
   const locale = await getMyLocale()
   redirect(`/${locale}`)
 }

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -10,7 +10,8 @@ import {
   Sidebar as UiSidebar,
 } from '@/components/ui/sidebar'
 import { Locale } from '@/i18n/locale'
-import { BRAND, ORGS } from '@/lib/starter.config'
+import { BRAND } from '@/lib/starter.config'
+import { CurrentOrgContext } from '@/organization/resolveCurrentOrgContext'
 import Image from 'next/image'
 import Link from 'next/link'
 import * as React from 'react'
@@ -23,12 +24,14 @@ import { SidebarOrgSection } from './SidebarOrgSection'
 import { SidebarOrgSwitcher } from './SidebarOrgSwitcher'
 
 export const Sidebar = ({
-  orgSlug,
+  orgContext,
+  canCreateOrg,
   locale,
   isLanding,
   ...props
 }: React.ComponentProps<typeof UiSidebar> & {
-  orgSlug?: string
+  orgContext?: CurrentOrgContext | null
+  canCreateOrg?: boolean
   locale?: Locale
   isLanding?: boolean
 }) => {
@@ -59,20 +62,25 @@ export const Sidebar = ({
           </SidebarMenuButton>
         </SidebarMenu>
 
-        {!!orgSlug && ORGS.isActive && (
-          <Suspense fallback={<Skeleton className="w-full h-[48px]" />}>
-            <SidebarOrgSwitcher orgSlug={orgSlug} />
-          </Suspense>
+        {orgContext && (
+          <SidebarOrgSwitcher
+            memberships={orgContext.memberships}
+            activeOrgSlug={orgContext.org.slug}
+            canCreateOrg={canCreateOrg}
+          />
         )}
       </SidebarHeader>
       <SidebarContent>
-        <Suspense fallback={<Skeleton className="w-full h-[48px]" />}>
-          {!!orgSlug && ORGS.isActive ? (
-            <SidebarOrgSection orgSlug={orgSlug} />
-          ) : (
+        {orgContext ? (
+          <SidebarOrgSection
+            org={orgContext.org}
+            role={orgContext.membership.role}
+          />
+        ) : (
+          <Suspense fallback={<Skeleton className="w-full h-[48px]" />}>
             <SidebarMainSection isLanding={isLanding} locale={locale} />
-          )}
-        </Suspense>
+          </Suspense>
+        )}
         {!isLanding && (
           <Suspense>
             <SidebarAdminSection />

--- a/src/components/sidebar/SidebarLayout.tsx
+++ b/src/components/sidebar/SidebarLayout.tsx
@@ -1,20 +1,37 @@
+import { getMyUser } from '@/auth/getMyUser'
+import { canUserCreateOrg } from '@/organization/canUserCreateOrg'
+import { LastUsedOrgCookieSync } from '@/organization/LastUsedOrgCookieSync'
+import { resolveCurrentOrgContext } from '@/organization/resolveCurrentOrgContext'
 import { DialogProvider } from '@/super-action/dialog/DialogProvider'
+import { notFound } from 'next/navigation'
 import { TopHeader } from '../TopHeader'
 import { SidebarInset, SidebarProvider } from '../ui/sidebar'
 import { Sidebar } from './Sidebar'
 
 export const SidebarLayout = async ({
   children,
-  params,
+  routeOrgSlug,
 }: {
   children: React.ReactNode
-  params?: Promise<{ orgSlug?: string }>
+  routeOrgSlug?: string
 }) => {
-  const orgSlug = (await params)?.orgSlug
+  const user = await getMyUser()
+  const [orgContext, userCanCreateOrg] = await Promise.all([
+    resolveCurrentOrgContext({ routeOrgSlug }),
+    user ? canUserCreateOrg() : Promise.resolve(false),
+  ])
+
+  if (routeOrgSlug && !orgContext) {
+    notFound()
+  }
+
   return (
     <>
       <SidebarProvider>
-        <Sidebar orgSlug={orgSlug} />
+        {orgContext && (
+          <LastUsedOrgCookieSync activeOrgSlug={orgContext.org.slug} />
+        )}
+        <Sidebar orgContext={orgContext} canCreateOrg={userCanCreateOrg} />
         <SidebarInset className="group/topheader flex min-w-0 flex-col gap-4 px-4">
           <TopHeader disableSeparator hideIfSecondTopHeaderExists></TopHeader>
           {children}

--- a/src/components/sidebar/SidebarOrgSection.tsx
+++ b/src/components/sidebar/SidebarOrgSection.tsx
@@ -4,8 +4,8 @@ import {
   SidebarMenu,
 } from '@/components/ui/sidebar'
 import { getTranslations } from '@/i18n/getTranslations'
-import { getMyMembershipOrNotFound } from '@/organization/getMyMembership'
 import { OrganizationRole } from '@/organization/organizationRoles'
+import { CurrentOrgContext } from '@/organization/resolveCurrentOrgContext'
 import { Building2, Home, Laugh, Users } from 'lucide-react'
 import { NavEntry } from '../layout/nav'
 import { SidebarNavEntry } from './SidebarNavEntry'
@@ -13,8 +13,13 @@ import { SidebarNavEntry } from './SidebarNavEntry'
 const defaultViewRoles: OrganizationRole[] = ['admin', 'member']
 const protectedViewRoles: OrganizationRole[] = ['admin']
 
-export const SidebarOrgSection = async ({ orgSlug }: { orgSlug: string }) => {
-  const { membership, org } = await getMyMembershipOrNotFound({ orgSlug })
+export const SidebarOrgSection = async ({
+  org,
+  role,
+}: {
+  org: CurrentOrgContext['org']
+  role: CurrentOrgContext['membership']['role']
+}) => {
   const t = await getTranslations()
 
   const items: NavEntry[] = [
@@ -36,14 +41,14 @@ export const SidebarOrgSection = async ({ orgSlug }: { orgSlug: string }) => {
       name: t.org.organization,
       href: `/org/${org.slug}/settings`,
       icon: <Building2 />,
-      hidden: !protectedViewRoles.includes(membership.role),
+      hidden: !protectedViewRoles.includes(role),
       exactMatch: true,
     },
     {
       name: t.org.members.title,
       href: `/org/${org.slug}/settings/members`,
       icon: <Users />,
-      hidden: !defaultViewRoles.includes(membership.role),
+      hidden: !defaultViewRoles.includes(role),
     },
   ]
 

--- a/src/components/sidebar/SidebarOrgSwitcher.tsx
+++ b/src/components/sidebar/SidebarOrgSwitcher.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { ChevronsUpDown, Plus } from 'lucide-react'
 
 import {
@@ -12,24 +14,28 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@/components/ui/sidebar'
-import { getTranslations } from '@/i18n/getTranslations'
-import { canUserCreateOrg } from '@/organization/canUserCreateOrg'
-import { getMyMemberships } from '@/organization/getMyMemberships'
+import { useTranslations } from '@/i18n/useTranslations'
+import { serializeLastUsedOrgCookie } from '@/organization/lastUsedOrgCookie'
+import { CurrentOrgContext } from '@/organization/resolveCurrentOrgContext'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { OrgAvatar } from '../OrgAvatar'
 import { ResponsiveDropdownMenuContent } from '../ResponsiveDropdownMenuContent'
 
-export const SidebarOrgSwitcher = async ({ orgSlug }: { orgSlug?: string }) => {
-  const [memberships, userCanCreateOrg] = await Promise.all([
-    getMyMemberships(),
-    canUserCreateOrg(),
-  ])
-
+export const SidebarOrgSwitcher = ({
+  memberships,
+  activeOrgSlug,
+  canCreateOrg,
+}: {
+  memberships: CurrentOrgContext['memberships']
+  activeOrgSlug: string
+  canCreateOrg?: boolean
+}) => {
+  const router = useRouter()
   const selectedMembership = memberships.find(
-    (membership) => membership.organization.slug === orgSlug,
+    (membership) => membership.organization.slug === activeOrgSlug,
   )
-
-  const t = await getTranslations()
+  const t = useTranslations()
 
   return (
     <SidebarMenu>
@@ -37,6 +43,7 @@ export const SidebarOrgSwitcher = async ({ orgSlug }: { orgSlug?: string }) => {
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <SidebarMenuButton
+              data-testid="sidebar-org-switcher-trigger"
               size="lg"
               className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
             >
@@ -66,15 +73,18 @@ export const SidebarOrgSwitcher = async ({ orgSlug }: { orgSlug?: string }) => {
               <DropdownMenuItem
                 key={membership.organization.id}
                 className="gap-2 py-2"
-                asChild
+                onSelect={() => {
+                  document.cookie = serializeLastUsedOrgCookie(
+                    membership.organization.slug,
+                  )
+                  router.push(`/org/${membership.organization.slug}`)
+                }}
               >
-                <Link href={`/org/${membership.organization.slug}`}>
-                  <OrgAvatar org={membership.organization} size={32} />
-                  {membership.organization.name}
-                </Link>
+                <OrgAvatar org={membership.organization} size={32} />
+                {membership.organization.name}
               </DropdownMenuItem>
             ))}
-            {userCanCreateOrg && (
+            {canCreateOrg && (
               <>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem className="gap-2 p-2" asChild>

--- a/src/lib/starter.config.tsx
+++ b/src/lib/starter.config.tsx
@@ -1,7 +1,15 @@
 import { type ExpirationTime } from '@/organization/inviteCodes/expirationTimes'
 
+/**
+ * Default starter config. The shipped E2E suite assumes this mode:
+ * - ORGS.isActive = true
+ * - LOCALIZATION.isActive = true
+ * - SIDEBAR.activeInMain = 'loggedIn'
+ * - ORGS.forceOrg = true
+ */
 export const ORGS = {
   isActive: true,
+  forceOrg: true, // Affects redirect, sidebar, and active-org-context tests.
   onlyAdminsCanCreateOrgs: false,
   defaultExpirationEmailInvitation: '1d' satisfies ExpirationTime,
 } as const

--- a/src/organization/LastUsedOrgCookieSync.tsx
+++ b/src/organization/LastUsedOrgCookieSync.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useEffect } from 'react'
+import { serializeLastUsedOrgCookie } from './lastUsedOrgCookie'
+
+export const LastUsedOrgCookieSync = ({
+  activeOrgSlug,
+}: {
+  activeOrgSlug: string
+}) => {
+  useEffect(() => {
+    document.cookie = serializeLastUsedOrgCookie(activeOrgSlug)
+  }, [activeOrgSlug])
+
+  return null
+}

--- a/src/organization/lastUsedOrgCookie.ts
+++ b/src/organization/lastUsedOrgCookie.ts
@@ -1,0 +1,6 @@
+export const LAST_USED_ORG_COOKIE_NAME = 'LastusedOrg'
+export const LAST_USED_ORG_COOKIE_MAX_AGE = 31536000
+
+export const serializeLastUsedOrgCookie = (orgSlug: string) => {
+  return `${LAST_USED_ORG_COOKIE_NAME}=${orgSlug}; path=/; max-age=${LAST_USED_ORG_COOKIE_MAX_AGE}; samesite=lax`
+}

--- a/src/organization/resolveCurrentOrgContext.ts
+++ b/src/organization/resolveCurrentOrgContext.ts
@@ -3,7 +3,7 @@ import { createClient, db } from '@/db/db'
 import { schema } from '@/db/schema-export'
 import { SIDEBAR, ORGS } from '@/lib/starter.config'
 import { superCache } from '@/lib/superCache'
-import { asc, desc, eq } from 'drizzle-orm'
+import { asc, desc, eq, sql } from 'drizzle-orm'
 import { cookies } from 'next/headers'
 import { after } from 'next/server'
 import { canUserCreateOrg } from './canUserCreateOrg'
@@ -38,6 +38,8 @@ type MembershipRow = CurrentOrgContext['memberships'][number] & {
   createdAt: Date
 }
 
+type MembershipQueryDatabase = Pick<typeof db, 'query'>
+
 const assertCurrentOrgConfig = () => {
   if (ORGS.forceOrg && !ORGS.isActive) {
     throw new Error(
@@ -52,8 +54,14 @@ const assertCurrentOrgConfig = () => {
   }
 }
 
-const getMembershipRows = async ({ userId }: { userId: string }) => {
-  return db.query.organizationMemberships.findMany({
+const getMembershipRows = async ({
+  database = db,
+  userId,
+}: {
+  database?: MembershipQueryDatabase
+  userId: string
+}) => {
+  return database.query.organizationMemberships.findMany({
     where: eq(schema.organizationMemberships.userId, userId),
     columns: {
       id: true,
@@ -136,6 +144,22 @@ const createDefaultOrgForUser = async ({
 
   try {
     const context = await transactionDb.transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${`auto-org:${userId}`})::bigint)`,
+      )
+
+      const existingMemberships = await getMembershipRows({
+        database: tx,
+        userId,
+      })
+
+      if (existingMemberships.length > 0) {
+        return toCurrentOrgContext({
+          activeMembership: existingMemberships[0],
+          memberships: existingMemberships,
+        })
+      }
+
       const existingOrg = await tx.query.organizations.findFirst({
         where: eq(schema.organizations.slug, userId),
         columns: {
@@ -215,9 +239,9 @@ const createDefaultOrgForUser = async ({
     })
 
     after(() => {
-      superCache.org({ id: context.org.id }).update()
-      superCache.orgMembers({ orgId: context.org.id }).update()
-      superCache.userOrgMemberships({ userId }).update()
+      superCache.org({ id: context.org.id }).revalidate()
+      superCache.orgMembers({ orgId: context.org.id }).revalidate()
+      superCache.userOrgMemberships({ userId }).revalidate()
     })
 
     return context

--- a/src/organization/resolveCurrentOrgContext.ts
+++ b/src/organization/resolveCurrentOrgContext.ts
@@ -1,0 +1,287 @@
+import { getMyUser } from '@/auth/getMyUser'
+import { createClient, db } from '@/db/db'
+import { schema } from '@/db/schema-export'
+import { SIDEBAR, ORGS } from '@/lib/starter.config'
+import { superCache } from '@/lib/superCache'
+import { asc, desc, eq } from 'drizzle-orm'
+import { cookies } from 'next/headers'
+import { after } from 'next/server'
+import { canUserCreateOrg } from './canUserCreateOrg'
+import { LAST_USED_ORG_COOKIE_NAME } from './lastUsedOrgCookie'
+
+export type CurrentOrgContext = {
+  org: {
+    id: string
+    slug: string
+    name: string
+  }
+  membership: {
+    id: string
+    role: 'admin' | 'member'
+    userId: string
+    organizationId: string
+  }
+  memberships: Array<{
+    id: string
+    role: 'admin' | 'member'
+    organization: {
+      id: string
+      slug: string
+      name: string
+    }
+  }>
+}
+
+type MembershipRow = CurrentOrgContext['memberships'][number] & {
+  userId: string
+  organizationId: string
+  createdAt: Date
+}
+
+const assertCurrentOrgConfig = () => {
+  if (ORGS.forceOrg && !ORGS.isActive) {
+    throw new Error(
+      'Invalid starter config: ORGS.forceOrg=true requires ORGS.isActive=true.',
+    )
+  }
+
+  if (ORGS.forceOrg && SIDEBAR.activeInMain === false) {
+    throw new Error(
+      'Invalid starter config: ORGS.forceOrg=true requires SIDEBAR.activeInMain to stay visible for logged-in users.',
+    )
+  }
+}
+
+const getMembershipRows = async ({ userId }: { userId: string }) => {
+  return db.query.organizationMemberships.findMany({
+    where: eq(schema.organizationMemberships.userId, userId),
+    columns: {
+      id: true,
+      role: true,
+      userId: true,
+      organizationId: true,
+      createdAt: true,
+    },
+    with: {
+      organization: {
+        columns: {
+          id: true,
+          slug: true,
+          name: true,
+        },
+      },
+    },
+    orderBy: [
+      desc(schema.organizationMemberships.createdAt),
+      asc(schema.organizationMemberships.organizationId),
+    ],
+  }) as Promise<MembershipRow[]>
+}
+
+const toCurrentOrgContext = ({
+  activeMembership,
+  memberships,
+}: {
+  activeMembership: MembershipRow
+  memberships: MembershipRow[]
+}): CurrentOrgContext => {
+  return {
+    org: activeMembership.organization,
+    membership: {
+      id: activeMembership.id,
+      role: activeMembership.role,
+      userId: activeMembership.userId,
+      organizationId: activeMembership.organizationId,
+    },
+    memberships: memberships.map(({ id, role, organization }) => ({
+      id,
+      role,
+      organization,
+    })),
+  }
+}
+
+const getDefaultOrgName = ({
+  userId,
+  userName,
+  userEmail,
+}: {
+  userId: string
+  userName?: string | null
+  userEmail?: string | null
+}) => {
+  const trimmedName = userName?.trim()
+  if (trimmedName) {
+    return trimmedName
+  }
+
+  const emailLocalPart = userEmail?.split('@').at(0)?.trim()
+  if (emailLocalPart) {
+    return emailLocalPart
+  }
+
+  return userId
+}
+
+const createDefaultOrgForUser = async ({
+  userId,
+  userName,
+  userEmail,
+}: {
+  userId: string
+  userName?: string | null
+  userEmail?: string | null
+}): Promise<CurrentOrgContext> => {
+  const { db: transactionDb, client } = await createClient()
+
+  try {
+    const context = await transactionDb.transaction(async (tx) => {
+      const existingOrg = await tx.query.organizations.findFirst({
+        where: eq(schema.organizations.slug, userId),
+        columns: {
+          id: true,
+        },
+      })
+
+      if (existingOrg) {
+        throw new Error(
+          `Unable to auto-create organization for user ${userId}: slug "${userId}" is already in use.`,
+        )
+      }
+
+      let org:
+        | {
+            id: string
+            slug: string
+            name: string
+          }
+        | undefined
+
+      try {
+        ;[org] = await tx
+          .insert(schema.organizations)
+          .values({
+            slug: userId,
+            name: getDefaultOrgName({ userId, userName, userEmail }),
+          })
+          .returning({
+            id: schema.organizations.id,
+            slug: schema.organizations.slug,
+            name: schema.organizations.name,
+          })
+      } catch (error) {
+        throw new Error(
+          `Unable to auto-create organization for user ${userId}: slug "${userId}" is already in use.`,
+          { cause: error },
+        )
+      }
+
+      if (!org) {
+        throw new Error(
+          `Unable to auto-create organization for user ${userId}: organization insert returned no row.`,
+        )
+      }
+
+      const [membership] = await tx
+        .insert(schema.organizationMemberships)
+        .values({
+          userId,
+          organizationId: org.id,
+          role: 'admin',
+        })
+        .returning({
+          id: schema.organizationMemberships.id,
+          role: schema.organizationMemberships.role,
+          userId: schema.organizationMemberships.userId,
+          organizationId: schema.organizationMemberships.organizationId,
+          createdAt: schema.organizationMemberships.createdAt,
+        })
+
+      if (!membership) {
+        throw new Error(
+          `Unable to auto-create organization for user ${userId}: membership insert returned no row.`,
+        )
+      }
+
+      const activeMembership: MembershipRow = {
+        ...membership,
+        organization: org,
+      }
+
+      return toCurrentOrgContext({
+        activeMembership,
+        memberships: [activeMembership],
+      })
+    })
+
+    after(() => {
+      superCache.org({ id: context.org.id }).update()
+      superCache.orgMembers({ orgId: context.org.id }).update()
+      superCache.userOrgMemberships({ userId }).update()
+    })
+
+    return context
+  } finally {
+    await client.end()
+  }
+}
+
+export const resolveCurrentOrgContext = async (options?: {
+  routeOrgSlug?: string
+}): Promise<CurrentOrgContext | null> => {
+  assertCurrentOrgConfig()
+
+  const user = await getMyUser()
+  if (!user) {
+    return null
+  }
+
+  const memberships = await getMembershipRows({ userId: user.id })
+
+  if (options?.routeOrgSlug) {
+    const activeMembership = memberships.find(
+      (membership) => membership.organization.slug === options.routeOrgSlug,
+    )
+
+    if (!activeMembership) {
+      return null
+    }
+
+    return toCurrentOrgContext({
+      activeMembership,
+      memberships,
+    })
+  }
+
+  if (!ORGS.forceOrg) {
+    return null
+  }
+
+  if (memberships.length > 0) {
+    const cookieStore = await cookies()
+    const lastUsedOrgSlug =
+      cookieStore.get(LAST_USED_ORG_COOKIE_NAME)?.value?.trim() || undefined
+
+    const activeMembership =
+      memberships.find(
+        (membership) => membership.organization.slug === lastUsedOrgSlug,
+      ) ?? memberships[0]
+
+    return toCurrentOrgContext({
+      activeMembership,
+      memberships,
+    })
+  }
+
+  if (await canUserCreateOrg()) {
+    return createDefaultOrgForUser({
+      userId: user.id,
+      userName: user.name,
+      userEmail: user.email,
+    })
+  }
+
+  throw new Error(
+    `Unable to resolve an active organization for user ${user.id}: the user has no memberships and cannot create an organization.`,
+  )
+}


### PR DESCRIPTION
## Summary
- add `ORGS.forceOrg` plus a server-side current-org resolver that enforces invariants, respects `LastusedOrg`, and auto-creates a default org for zero-org users
- route logged-in `/` and `/app` to `/org/{slug}` while keeping global main routes on their existing URLs with an active org sidebar context
- update README expectations and E2E coverage for landing redirects, zero-org auto-create, and LastusedOrg fallback behavior

## Testing
- `pnpm format`
- `pnpm ts:check`
- `pnpm lint`
- `E2E_WORKERS=1 pnpm e2e:ci -- e2e/specs/landing-and-routing.spec.ts`
- `E2E_WORKERS=1 pnpm e2e:ci -- e2e/specs/force-org.spec.ts`